### PR TITLE
Update board.txt

### DIFF
--- a/uecide/boards/olimex-pinguino32-obl/board.txt
+++ b/uecide/boards/olimex-pinguino32-obl/board.txt
@@ -36,7 +36,7 @@ upload.hid.ldsuffix=
 upload.hid.command.linux_arm=${core.root}/tools/linux_arm/pic32prog::-p::${filename}.hex
 upload.hid.command.linux_i386=${core.root}/tools/linux32/pic32prog::-p::${filename}.hex
 upload.hid.command.linux_amd64=${core.root}/tools/linux64/pic32prog::-p::${filename}.hex
-upload.hid.command.windows=${board.root}/tools/windows/mphidflash::-r::-w::${filename}.hex
+upload.hid.command.windows=${board.root}/tools/windows/mphidflash.exe::-r::-w::${filename}.hex
 upload.hid.command.macosx=${board.root}/tools/osx/mphidflash::-r::-w::${filename}.hex
 
 sketch.upload=mphid::avrdude


### PR DESCRIPTION
had to specify mphidflash.exe file extension on Windows 10 to be able to upload sketch from UECIDE